### PR TITLE
Make scripts work when run in AWS Lambda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME    := xks-proxy-test-client
-VERSION := 1.0.3
+VERSION := 1.0.4
 RELEASE := 0
 SOURCE_BUNDLE := $(NAME)-$(VERSION)-$(RELEASE).txz
 PROJECT_ROOTDIR := $(shell basename $(CURDIR))

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ implemenations of the AWS KMS External Keystore (XKS) Proxy API over HTTP or HTT
 * `sed`
 * `sha256sum`
 * `tr`
-* `which`
 * `xxd`
 
 ## Examples
@@ -127,6 +126,8 @@ and is typically pre-installed in a Linux distribution.
 
 ## Change log
 
+* Mon Sep 26 2022 Hanson Char <hchar@amazon.com> - 1.0.4
+    - Make scripts work when run in AWS Lambda
 * Mon Sep 5 2022 Hanson Char <hchar@amazon.com> - 1.0.3
     - Initial release
 

--- a/test-xks-proxy
+++ b/test-xks-proxy
@@ -5,7 +5,7 @@
 
 usage() {
     cat <<-EOM
-Version 1.0.3.  Sample usages:
+Version 1.0.4.  Sample usages:
 
     # Show this help message.
     ./test-xks-proxy -h
@@ -86,7 +86,11 @@ declare -r all_test=$(( ${#@} == 1 && all_options[$1] ))
 source ./utils/test_utils.sh
 check_environment
 
-tmpdir="$(mktemp -d)"
+# Use -p /tmp to get around AWS Lambda which by default has a read-only file system
+if ! tmpdir="$(mktemp -d -p /tmp 2>/dev/null)"; then
+    # mktemp in Mac OSX doesn't support -p
+    tmpdir="$(mktemp -d)"
+fi
 declare -r tmpdir
 trap 'rm -rf -- "$tmpdir"' exit
 

--- a/test_encrypt_decrypt
+++ b/test_encrypt_decrypt
@@ -196,7 +196,11 @@ if ((${#@})); then
     echo "$success $failure" > "$counts_file"
 else
     check_environment
-    tmpdir="$(mktemp -d)"
+    # Use -p /tmp to get around AWS Lambda which by default has a read-only file system
+    if ! tmpdir="$(mktemp -d -p /tmp 2>/dev/null)"; then
+        # mktemp in Mac OSX doesn't support -p
+        tmpdir="$(mktemp -d)"
+    fi
     declare -r tmpdir
     trap 'rm -rf -- "$tmpdir"' exit
 

--- a/utils/test_utils.sh
+++ b/utils/test_utils.sh
@@ -92,7 +92,7 @@ EOM
     print_header "Testing $label ..."
 
     echo "Request body ..."
-    jq <<< "$json_body"
+    jq '.' <<< "$json_body"
     echo -e "${reset}"
 
     # shellcheck disable=SC2207
@@ -107,7 +107,7 @@ EOM
     echo -e "${reset}\nResponse body ..."
     last_json_body="${arr[n-1]}"
     if [[ "$last_json_body" =~ ^\{.*\}$ ]]; then
-        jq <<< "$last_json_body"
+        jq '.' <<< "$last_json_body"
     else
         echo "$last_json_body"
     fi
@@ -151,7 +151,7 @@ check_environment() {
 
         local -r extract_version_cmd="$3"
 
-        if ! which "$cmd" > /dev/null; then
+        if ! type "$cmd" > /dev/null; then
             abort "Please install $cmd $min_major.$min_minor or later for use with this test client."
         fi
 
@@ -164,10 +164,9 @@ check_environment() {
             abort "Please install $cmd $min_major.$min_minor or later for use with this test client."
         fi
     }
-
     local cmd
     for cmd in awk base64 head mktemp printf read sed sha256sum tr xxd; do
-        if which $cmd > /dev/null; then
+        if type $cmd > /dev/null; then
             ((DEBUG)) && echo "$cmd is available ..." > /dev/stderr
         else
             abort "Please install $cmd for use with this test client."


### PR DESCRIPTION
- use 'type' instead of 'which' to check for existence of commands
- make use of /tmp to get around the default read-only file system in Lambda
- adjust some uses of the 'jq' command so it won't fail when run in Lambda
- upgrade to v1.0.4

*Issue #, if available:*

*Description of changes:*

 Make scripts work when run in AWS Lambda
    - use `type` instead of `which` to check for existence of commands
    - make use of `/tmp` to get around the default read-only file system in Lambda
    - adjust some uses of the `jq` command so it won't fail when run in Lambda
    - upgrade to `v1.0.4`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
