### PR TITLE
Fix "Segmentation fault: 11" when run on OSX, upgrading to v1.0.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME    := xks-proxy-test-client
-VERSION := 1.0.5
+VERSION := 1.0.6
 RELEASE := 0
 SOURCE_BUNDLE := $(NAME)-$(VERSION)-$(RELEASE).txz
 PROJECT_ROOTDIR := $(shell basename $(CURDIR))

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ implemenations of the AWS KMS External Keystore (XKS) Proxy API over HTTP or HTT
 
 # Version
 
-`1.0.5`
+`1.0.6`
 
 ## Dependencies
 
@@ -130,6 +130,8 @@ and is typically pre-installed in a Linux distribution.
 
 ## Change log
 
+* Wed Sep 28 2022 Hanson Char <hchar@amazon.com> - 1.0.6
+    - Fix "Segmentation fault: 11" when run on OSX
 * Mon Sep 26 2022 Hanson Char <hchar@amazon.com> - 1.0.5
     - Supports ASCII_ESCAPE to toggle the use of ASCII Escape codes in the output
 * Mon Sep 26 2022 Hanson Char <hchar@amazon.com> - 1.0.4

--- a/test-xks-proxy
+++ b/test-xks-proxy
@@ -5,7 +5,7 @@
 
 usage() {
     cat <<-EOM
-Version 1.0.5.  Sample usages:
+Version 1.0.6.  Sample usages:
 
     # Show this help message.
     ./test-xks-proxy -h
@@ -50,37 +50,22 @@ Simply type "cat utils/test_config.sh" to see the full list; or check out README
 EOM
 }
 
-# Any of these as the first parameter would show the usage info.
-declare -Ar help_options=(
-    [h]=1
-    [help]=1
-    [-h]=1
-    [-H]=1
-    [-help]=1
-    [--help]=1
-    [v]=1
-    [version]=1
-    [-v]=1
-    [-V]=1
-    [-version]=1
-    [--version]=1
-)
-
-declare -Ar all_options=(
-    [a]=1
-    [all]=1
-    [-a]=1
-    [-A]=1
-    [-all]=1
-    [--all]=1
-)
-
-if (( ${#@} > 1 || ${#@} == 1 && help_options[$1] )); then
-    usage
-    exit
-fi
-
-declare -r all_test=$(( ${#@} == 1 && all_options[$1] ))
+# https://wiki.bash-hackers.org/howto/getopts_tutorial
+while getopts ":ha" opt; do
+  case $opt in
+    h)
+      usage
+      exit
+      ;;
+    a)
+      declare -r all_test=1
+      ;;
+    \?)
+      usage
+      exit
+      ;;
+  esac
+done
 
 # shellcheck disable=SC1091
 source ./utils/test_utils.sh

--- a/utils/test_utils.sh
+++ b/utils/test_utils.sh
@@ -58,7 +58,6 @@ EOM
     # without the "--silent" parameter curl could fail on AL2 with large AAD and plaintext
     build_command() {
         local -r uri_target="$1" json_body="$2"
-        local command
         cat <<-EOM
 curl $SCHEME$XKS_PROXY_HOST/$URI_PREFIX/kms/xks/v1/$uri_target \\
     --silent $VERBOSE $SECURE $MTLS \\
@@ -74,7 +73,7 @@ EOM
 
     post() {
         local -r uri_target="$1" json_body="$2"
-        command="$(build_command "$@")"
+        local -r command="$(build_command "$@")"
 
         if ((DEBUG)); then
             # shellcheck disable=SC2086


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* I suddenly got a "Segmentation fault: 11" on OSX this morning.  It seems related to the `bash` binary I may have updated via `homebrew`.   However, instead of trying to fix the `bash` binary I thought it's probably better to make the scripts run under all possible environments regardless.
* Simplify the code a bit using `getopts`, which is considered the best practices in `bash`.
* Plus some minor fixes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
