### PR TITLE
Disable stdout when testing the base64 command

### DIFF
--- a/test_encrypt_decrypt
+++ b/test_encrypt_decrypt
@@ -162,7 +162,7 @@ main() {
     local large_aad large_plaintext
     # The base64 command on AL2 requires explicitly disabling line wrapping
     local base64_command
-    if base64 -w 0 <<< "" 2>/dev/null; then
+    if base64 -w 0 <<< "" 1>/dev/null 2>&1; then
         base64_command="base64 -w 0"
     else
         base64_command="base64"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change removes an unexpected side effect which could potential become a source of subtle bugs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
