### PR TITLE
Fix spelling typo changing "ASCII_ESCAPE" with "ANSI_ESCAPE", bumping to v1.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME    := xks-proxy-test-client
-VERSION := 1.0.6
+VERSION := 1.1.0
 RELEASE := 0
 SOURCE_BUNDLE := $(NAME)-$(VERSION)-$(RELEASE).txz
 PROJECT_ROOTDIR := $(shell basename $(CURDIR))

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ implemenations of the AWS KMS External Keystore (XKS) Proxy API over HTTP or HTT
 
 # Version
 
-`1.0.6`
+`1.1.0`
 
 ## Dependencies
 
@@ -115,9 +115,9 @@ The following environment variables can be used to override the default settings
     * Default to `0` to disable debugging output
     * Can be set to `1` to enable debugging output, printing the actual `curl` command being run
 
-* `ASCII_ESCAPE` - used to toggle the use of ASCII Escape codes in the output
-    * Default to `1` to enable the use of ASCII Escape codes in the output
-    * Can be set to `0` to disable the use of ASCII Escape codes in the output
+* `ANSI_ESCAPE` - used to toggle the use of ANSI Escape codes in the output
+    * Default to `1` to enable the use of ANSI Escape codes in the output
+    * Can be set to `0` to disable the use of ANSI Escape codes in the output
 
 ## Notes
 
@@ -130,10 +130,12 @@ and is typically pre-installed in a Linux distribution.
 
 ## Change log
 
+* Wed Oct 5 2022 Hanson Char <hchar@amazon.com> - 1.1.0
+    - Fix typo, changing "ASCII_ESCAPE" to "ANSI_ESCAPE"
 * Wed Sep 28 2022 Hanson Char <hchar@amazon.com> - 1.0.6
     - Fix "Segmentation fault: 11" when run on OSX
 * Mon Sep 26 2022 Hanson Char <hchar@amazon.com> - 1.0.5
-    - Supports ASCII_ESCAPE to toggle the use of ASCII Escape codes in the output
+    - Supports ANSI_ESCAPE to toggle the use of ANSI Escape codes in the output
 * Mon Sep 26 2022 Hanson Char <hchar@amazon.com> - 1.0.4
     - Make scripts work when run in AWS Lambda
 * Mon Sep 5 2022 Hanson Char <hchar@amazon.com> - 1.0.3

--- a/test-xks-proxy
+++ b/test-xks-proxy
@@ -5,7 +5,7 @@
 
 usage() {
     cat <<-EOM
-Version 1.0.6.  Sample usages:
+Version 1.1.0.  Sample usages:
 
     # Show this help message.
     ./test-xks-proxy -h

--- a/utils/test_config.sh
+++ b/utils/test_config.sh
@@ -15,7 +15,7 @@ declare -r DEFAULT_SECURE=""
 declare -r DEFAULT_VERBOSE="-i"
 declare -r DEFAULT_MTLS=""
 declare -ri DEFAULT_DEBUG=0
-declare -ri DEFAULT_ASCII_ESCAPE=1
+declare -ri DEFAULT_ANSI_ESCAPE=1
 
 # xks-proxy endpoint
 declare XKS_PROXY_HOST=${XKS_PROXY_HOST-${DEFAULT_XKS_PROXY_HOST}}
@@ -56,6 +56,6 @@ declare -i DEBUG=${DEBUG-${DEFAULT_DEBUG}}
 # Example: MTLS_KEY="--key mtls/test_key.pem --cert mtls/test_cert.pem"
 declare MTLS=${MTLS-${DEFAULT_MTLS}}
 
-# ASCII_ESCAPE=0 to disable the use of ASCII Escape codes in the output
-# ASCII_ESCAPE=1 to enable the use of ASCII Escape codes in the output
-declare -i ASCII_ESCAPE=${ASCII_ESCAPE-${DEFAULT_ASCII_ESCAPE}}
+# ANSI_ESCAPE=0 to disable the use of ANSI Escape codes in the output
+# ANSI_ESCAPE=1 to enable the use of ANSI Escape codes in the output
+declare -i ANSI_ESCAPE=${ANSI_ESCAPE-${DEFAULT_ANSI_ESCAPE}}

--- a/utils/test_utils.sh
+++ b/utils/test_utils.sh
@@ -6,7 +6,7 @@
 # shellcheck disable=SC1091
 source ./utils/test_config.sh
 
-if ((ASCII_ESCAPE)); then
+if ((ANSI_ESCAPE)); then
     # https://en.wikipedia.org/wiki/Box-drawing_character#Box_Drawing
     declare -r top_left=$'\u250f' horizontal=$'\u2501' top_right=$'\u2513' vertical=$'\u2503'
     declare -r bottom_left=$'\u2517' bottom_right=$'\u251b'
@@ -98,7 +98,7 @@ EOM
     print_header "Testing $label ..."
 
     echo "Request body ..."
-    if ((ASCII_ESCAPE)); then
+    if ((ANSI_ESCAPE)); then
         jq '.' -C <<< "$json_body"
     else
         jq '.' -M -a <<< "$json_body"
@@ -117,7 +117,7 @@ EOM
     echo -e "${reset}\nResponse body ..."
     last_json_body="${arr[n-1]}"
     if [[ "$last_json_body" =~ ^\{.*\}$ ]]; then
-        if ((ASCII_ESCAPE)); then
+        if ((ANSI_ESCAPE)); then
             jq '.' -C <<< "$last_json_body"
         else
             jq '.' -M -a <<< "$last_json_body"


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

The title has it all.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
