### PR TITLE
Allow latest jq to be used

### DIFF
--- a/utils/test_utils.sh
+++ b/utils/test_utils.sh
@@ -191,6 +191,12 @@ check_environment() {
         "bash --version | head -1 | sed -e 's/.*version \([0-9]*.[0-9]*\).*/\1/'"
     check_min_version "curl" "7.75" \
         "curl --version | head -1 | sed -e 's/^curl \([0-9]*.[0-9]*\).*/\1/'"
-    check_min_version "jq"   "1.5" \
-        "jq --version | head -1 | sed -e 's/^jq-\([0-9]*.[0-9]*\).*/\1/'"
+
+    local -r jq_version="$(jq --version | head -1)"
+    if [[ "$jq_version" = jq-master-* ]]; then
+        ((DEBUG)) && echo "jq version $jq_version is available ..." > /dev/stderr
+    else
+        check_min_version "jq" "1.5" \
+            "echo $jq_version | sed -e 's/^jq-\([0-9]*.[0-9]*\).*/\1/'"
+    fi
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There is an edge case when Alpine Linux is in use the installed latest `jq` is named with the prefix `jq-master`.  This PR therefore relaxes the check for that edge case instead of rejecting it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

