### PR TITLE
Handle MTLS properly in test-xks-proxy-via-docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,32 +68,50 @@ jobs:
               exit 1
           fi
 
-      - name: Prepare mTLS key
-        env:
-          MTLS_TEST_KEY: ${{ env.XKSPROXY_CLIENT_TEST_MTLS_KEY_PEM }}
-        run: 'echo -ne "$MTLS_TEST_KEY" > "./key.pem"'
-        shell: bash
+      - name: Make Docker container
+        run: make docker
 
-      - name: Prepare mTLS cert
+      - name: Run all https tests against xks-proxy via Docker
         env:
-          MTLS_TEST_CERT: ${{ env.XKSPROXY_CLIENT_TEST_MTLS_CERT_PEM }}
-        run: 'echo -ne "$MTLS_TEST_CERT" > "./cert.pem"'
-        shell: bash
+          XKS_PROXY_HOST: ${{ secrets.XKS_PROXY_HTTPS_TEST_HOST }}
+        run: |
+          TTY= ./test-xks-proxy-via-docker -a | tee ./response.txt
+          result=$(tail -1 ./response.txt)
+          if ! [[ "$result" =~ ^.*All && "$result" =~ PASSED.*$ ]]; then
+              exit 1
+          fi
 
       - name: Prepare mTLS CA bundle
         env:
           MTLS_CA_BUNDLE: ${{ secrets.MTLS_CA_BUNDLE }}
-        run: 'echo "$MTLS_CA_BUNDLE" > "./ca-bundle.pem"'
+        run: 'echo -n "$MTLS_CA_BUNDLE" > "./ca-bundle.pem"'
         shell: bash
 
       - name: Run all mTLS tests against xks-proxy
         env:
+          MTLS_TEST_KEY: ${{ env.XKSPROXY_CLIENT_TEST_MTLS_KEY_PEM }}
+          MTLS_TEST_CERT: ${{ env.XKSPROXY_CLIENT_TEST_MTLS_CERT_PEM }}
           XKS_PROXY_HOST: ${{ secrets.XKS_PROXY_MTLS_TEST_HOST }}
           CURL_CA_BUNDLE: ./ca-bundle.pem
-          MTLS: "--key ./key.pem --cert ./cert.pem"
+          # Note both the keys and certs are encoded with '\n' in AWS Secrets Manager.
+          # Hence the use of -e to convert them into line breaks.
+          MTLS: --key <(echo -ne "$MTLS_TEST_KEY") --cert <(echo -ne "$MTLS_TEST_CERT")
         run: |
           trap 'rm -f ./*.pem' exit
           ./test-xks-proxy -a | tee ./response.txt
+          result=$(tail -1 ./response.txt)
+          if ! [[ "$result" =~ ^.*All && "$result" =~ PASSED.*$ ]]; then
+              exit 1
+          fi
+
+      - name: Run all mTLS tests against xks-proxy via Docker
+        env:
+          MTLS_TEST_KEY: ${{ env.XKSPROXY_CLIENT_TEST_MTLS_KEY_PEM }}
+          MTLS_TEST_CERT: ${{ env.XKSPROXY_CLIENT_TEST_MTLS_CERT_PEM }}
+          XKS_PROXY_HOST: ${{ secrets.XKS_PROXY_MTLS_TEST_HOST }}
+          MTLS: --key <(echo -ne "$MTLS_TEST_KEY") --cert <(echo -ne "$MTLS_TEST_CERT")
+        run: |
+          TTY= ./test-xks-proxy-via-docker -a | tee ./response.txt
           result=$(tail -1 ./response.txt)
           if ! [[ "$result" =~ ^.*All && "$result" =~ PASSED.*$ ]]; then
               exit 1

--- a/test-xks-proxy-via-docker
+++ b/test-xks-proxy-via-docker
@@ -1,5 +1,35 @@
 #!/usr/bin/env bash
 
-docker run -it --rm --network="host" \
---env-file <(env |grep -E '(XKS_PROXY_HOST|URI_PREFIX|REGION|VERBOSE|KEY_ID|ENCRYPT_ONLY_KEY_ID|DECRYPT_ONLY_KEY_ID|IMPOTENT_KEY_ID|SCHEME|SECURE|MTLS|DEBUG|ANSI_ESCAPE|SIGV4_ACCESS_KEY_ID|SIGV4_SECRET_ACCESS_KEY)') \
+# https://stackoverflow.com/questions/3915040/how-to-obtain-the-absolute-path-of-a-file-via-shell-bash-zsh-sh
+# shellcheck disable=SC2164
+to_absolute_path() {
+    echo "$(cd "$(dirname -- "$1")" >/dev/null; pwd -P)/$(basename -- "$1")"
+}
+
+MOUNT_MTLS_PARAM=""
+if [[ -n "$MTLS" ]]; then
+    read -r -a parts <<< "$MTLS"
+    if (( ${#parts[@]} == 4 )); then
+        parts[1]=$(to_absolute_path "${parts[1]}")
+        parts[3]=$(to_absolute_path "${parts[3]}")
+        MTLS="${parts[*]}"
+        MOUNT_MTLS_PARAM="-v ${parts[1]}:${parts[1]} -v ${parts[3]}:${parts[3]}"
+    fi
+fi
+
+# For completeness when CURL_CA_BUNDLE is specified
+MOUNT_CA_BUNDLE_PARAM=""
+if [[ -n "$CURL_CA_BUNDLE" ]]; then
+    CURL_CA_BUNDLE=$(to_absolute_path "$CURL_CA_BUNDLE")
+    MOUNT_CA_BUNDLE_PARAM="-v $CURL_CA_BUNDLE:$CURL_CA_BUNDLE"
+fi
+
+# Used to handle "the input device is not a TTY" failure when run in Github action
+TTY=${TTY-"-it"}
+
+# shellcheck disable=SC2086
+docker run $TTY --rm --network="host" \
+$MOUNT_MTLS_PARAM \
+$MOUNT_CA_BUNDLE_PARAM \
+--env-file <(env |grep -E '(XKS_PROXY_HOST|URI_PREFIX|REGION|VERBOSE|KEY_ID|ENCRYPT_ONLY_KEY_ID|DECRYPT_ONLY_KEY_ID|IMPOTENT_KEY_ID|SCHEME|SECURE|MTLS|DEBUG|ANSI_ESCAPE|SIGV4_ACCESS_KEY_ID|SIGV4_SECRET_ACCESS_KEY|CURL_CA_BUNDLE)') \
     test-xks-proxy test-xks-proxy "$@"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. The existing script `test-xks-proxy-via-docker` didn't handle the `MTLS` parameter properly.  This PR fixes it.
2. Add integration tests when the test client is run in Docker
3. Simplify retrieval of key/cert in Github Actions

Successful workflow run: https://github.com/hansonchar/aws-kms-xksproxy-test-client/actions/runs/3422798381

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

